### PR TITLE
Enable Python 3 compatibility in merge

### DIFF
--- a/InfoGAN-Tutorial.ipynb
+++ b/InfoGAN-Tutorial.ipynb
@@ -93,7 +93,7 @@
     "\n",
     "    for idx, image in enumerate(images):\n",
     "        i = idx % size[1]\n",
-    "        j = idx / size[1]\n",
+    "        j = idx // size[1]\n",
     "        img[j*h:j*h+h, i*w:i*w+w] = image\n",
     "\n",
     "    return img"


### PR DESCRIPTION
Python 3.5 needs integer division performed with `//` to avoid broadcast type error:

`ValueError: could not broadcast input array from shape (32,32) into shape (29,32)`
